### PR TITLE
Added build matrix.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,19 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
     - TARGET_ARCH: x64
+      CONDA_PY: 27
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 34
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,10 @@ source:
 
 build:
     number: 1
-    skip: True  # [py35 and win32]
+    features:
+     - vc9  # [win and py27]
+     - vc10  # [win and py34]
+     - vc14  # [win and py35]
 
 requirements:
     run:


### PR DESCRIPTION
Cartopy's recipe is still failing because proj.4 for py3k was no build. conda-smithy (correctly) did not add PY3K into the build matrix as the recipes has not real python dependency,
