### PR TITLE
Use proj-datumgrid 1.6

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,9 @@
+cd %SRC_DIR%\nad
+curl -fsS -o proj-datumgrid-1.6.zip http://download.osgeo.org/proj/proj-datumgrid-1.6.zip
+7z x proj-datumgrid-1.6.zip
+del proj-datumgrid-1.6.zip
+cd ..
+
 nmake /f makefile.vc
 
 nmake INSTDIR=%LIBRARY_PREFIX% /f makefile.vc install-all

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+pushd $SRC_DIR/nad
+# FIXME: check the sha256 manually 054e7b63b474926c79f25fbe5cd8760351e8d93e5a167b5473e993c01bb08866
+curl -L -O http://download.osgeo.org/proj/proj-datumgrid-1.6.zip
+unzip -o proj-datumgrid-1.6.zip
+rm -rf proj-datumgrid-1.6.zip
+popd
+
+
 ./configure --prefix=$PREFIX --without-jni
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
@@ -20,6 +20,7 @@ requirements:
   build:
     - python  # [win]
     - cmake  # [win]
+    - unzip  # [not win]
     - vc 9  # [win and py27]
     - vc 10  # [win and py34]
     - vc 14  # [win and py35]
@@ -30,6 +31,9 @@ requirements:
 
 test:
   commands:
+    # Check if NAD27/NAD83 datum shifting is present if `conus` is present.
+    - test -f $PREFIX/share/proj/conus  # [not win]
+    - if not exist %PREFIX%\\Library\\SHARE\\conus exit 1  # [win]
     - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
     - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
     - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975

--- a/recipe/nadshift.patch
+++ b/recipe/nadshift.patch
@@ -1,0 +1,11 @@
+--- proj-4.9.3.orig/makefile.vc	2016-08-29 15:47:58.000000000 -0300
++++ proj-4.9.3/makefile.vc	2016-11-16 11:40:07.719473264 -0300
+@@ -9,7 +9,7 @@
+ 
+ default:    
+ 	cd src
+-	$(MAKE) /f makefile.vc
++	$(MAKE) /f makefile.vc nadshift
+ 	cd ..\nad
+ 	$(MAKE) /f makefile.vc
+ 	cd ..


### PR DESCRIPTION
@pelson I know you are quite busy but if you can find some time to check the changes here I appreciate it. 

I am adding this change based on a request from people at my day job, but I am not sure about the consequences downstream (`cartopy`).

For example, the command

```shell
echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
```

will return `117d0'2.901"W   30d0'0.407"N 0.000` instead of `117dW   30dN 0.000`.

See https://github.com/OSGeo/proj.4/wiki/FAQ for more info.