### PR TITLE
Port env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ conda search proj4 --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 
@@ -71,9 +70,9 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/home-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/home-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/home-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/home-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/home-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/home-feedstock/branch/master)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/proj.4-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/proj.4-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/proj.4-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/proj.4-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/proj.4-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/proj-4-feedstock/branch/master)
 
 Current release info
 ====================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +21,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +62,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,3 +5,14 @@ if errorlevel 1 exit 1
 
 move %LIBRARY_PREFIX%\bin\*.* %PREFIX%
 if errorlevel 1 exit 1
+
+set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
+set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
+mkdir %ACTIVATE_DIR%
+mkdir %DEACTIVATE_DIR%
+
+copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\proj4-activate.bat
+if errorlevel 1 exit 1
+
+copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\proj4-deactivate.bat
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,3 +5,11 @@
 make
 make check
 make install
+
+ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+mkdir -p $ACTIVATE_DIR
+mkdir -p $DEACTIVATE_DIR
+
+cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/proj4-activate.sh
+cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/proj4-deactivate.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9  # [win and py27]
     - vc10  # [win and py34]
@@ -32,6 +32,7 @@ test:
   commands:
     - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
     - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
+    - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975
     #- conda inspect linkages -p $PREFIX proj4  # [not win]
     #- conda inspect objects -p $PREFIX proj4  # [osx]
 

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,0 +1,7 @@
+:: Store existing env vars and set to this conda env
+:: so other installs don't pollute the environment.
+
+@if defined PROJ_LIB (
+    set "_CONDA_SET_PROJ_LIB=%PROJ_LIB%"
+)
+@set "PROJ_LIB=%CONDA_PREFIX%\Library\share"

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Store existing env vars and set to this conda env
+# so other installs don't pollute the environment.
+
+if [[ -n "PROJ_LIB" ]]; then
+    export _CONDA_SET_PROJ_LIB=PROJ_LIB
+fi
+
+export PROJ_LIB=$CONDA_PREFIX/share/proj

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,0 +1,7 @@
+:: Restore previous GDAL env vars if they were set.
+
+set "PROJ_LIB="
+if defined _CONDA_SET_PROJ_LIB (
+  set "PROJ_LIB=%_CONDA_SET_PROJ_LIB%"
+  set "_CONDA_SET_PROJ_LIB="
+)

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Restore previous env vars if they were set.
+unset PROJ_LIB
+if [[ -n "$_CONDA_SET_PROJ_LIB" ]]; then
+    export PROJ_LIB=$_CONDA_SET_PROJ_LIB
+    unset _CONDA_SET_PROJ_LIB
+fi


### PR DESCRIPTION
Fixes #18 

@megies this is the same logic I implemented in #17, but since that one may take a while to get merged I backported it here.

Note that the env var only works when using `conda-env`. Installing `proj4` in the root env will still suffer from that problem.