### PR TITLE
Add csh and fish activation/deactivation scripts to 5.2.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,10 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+    - CONFIG: win_c_compilervs2008cxx_compilervs2008
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,8 +10,12 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2015cxx_compilervs2015vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+      win_c_compilervs2008cxx_compilervs2008:
+        CONFIG: win_c_compilervs2008cxx_compilervs2008
+        CONDA_BLD_PATH: D:\\bld\\
+        UPLOAD_PACKAGES: False
+      win_c_compilervs2015cxx_compilervs2015:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: False
   steps:

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -12,12 +12,3 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-pin_run_as_build:
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
-sqlite:
-- '3'
-zlib:
-- '1.2'

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -16,12 +16,3 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-pin_run_as_build:
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
-sqlite:
-- '3'
-zlib:
-- '1.2'

--- a/.ci_support/win_c_compilervs2008cxx_compilervs2008.yaml
+++ b/.ci_support/win_c_compilervs2008cxx_compilervs2008.yaml
@@ -1,0 +1,13 @@
+CMAKE_GENERATOR:
+- NMake Makefiles
+c_compiler:
+- vs2008
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2008
+zip_keys:
+- - c_compiler
+  - cxx_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015.yaml
@@ -8,16 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2015
-pin_run_as_build:
-  sqlite:
-    max_pin: x
-  vc:
-    max_pin: x
-sqlite:
-- '3'
-vc:
-- '14'
 zip_keys:
-- - vc
-  - c_compiler
+- - c_compiler
   - cxx_compiler

--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015vc14</td>
+              <td>win_c_compilervs2008cxx_compilervs2008</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=815&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proj.4-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proj.4-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2008cxx_compilervs2008" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_c_compilervs2015cxx_compilervs2015</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=815&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/proj.4-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,6 @@
-mkdir build
-cd build
-cmake -G "%CMAKE_GENERATOR%" .. -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBPROJ_SHARED="ON" -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"
-cmake --build . --config Release --target install
-cd ..
-copy /Y data\* %LIBRARY_PREFIX%\\share\\proj
-del /F /Q %LIBRARY_PREFIX%\\share\\proj\\*.cmake
+nmake /f makefile.vc
 
+nmake INSTDIR=%LIBRARY_PREFIX% /f makefile.vc install-all
 if errorlevel 1 exit 1
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "6.1.0" %}
-{% set datumgrid_ver = "1.8" %}
+{% set version = "5.2.0" %}
+{% set datumgrid_ver = "1.7" %}
 
 package:
   name: proj4
@@ -7,14 +7,13 @@ package:
 
 source:
   - url: http://download.osgeo.org/proj/proj-{{ version }}.tar.gz
-    sha256: 676165c54319d2f03da4349cbd7344eb430b225fe867a90191d848dc64788008
+    sha256: ef919499ffbc62a4aae2659a55e2b25ff09cccbbe230656ba71c6224056c7e60
   - url: http://download.osgeo.org/proj/proj-datumgrid-{{ datumgrid_ver }}.zip
-    sha256: b9838ae7e5f27ee732fb0bfed618f85b36e8bb56d7afb287d506338e9f33861e
-    folder: data
+    sha256: ffcad4453fac3b4a13ca678ef343e688496e18019f35709ef03c5f200e9fb85a
+    folder: nad
 
 build:
-  number: 1
-  skip: True  # [win and vc<14]
+  number: 1002
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/
@@ -27,12 +26,6 @@ requirements:
     - make  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
-    - sqlite
-    - zlib  # [not win]
-  run:
-    - sqlite
-    - zlib  # [not win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
   commands:
     # Check if NAD27/NAD83 datum shifting is present if `conus` is present.
     - test -f $PREFIX/share/proj/conus  # [not win]
-    - if not exist %LIBRARY_PREFIX%\\share\\proj\\conus exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\SHARE\\conus exit 1  # [win]
     - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
     - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
     - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975


### PR DESCRIPTION
v6.x is not supported by some downstream packages (`basemap` is the one I'm aware of, which requires `pyproj` < 2.0 and therefore `proj4` < 6.0).

This branch will be merged to the v5.2.0 branch, not to `master`, avoiding the need to revert.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
