### PR TITLE
Always create a proj.lib on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,33 @@
 mkdir build
 cd build
 cmake -G "%CMAKE_GENERATOR%" .. -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBPROJ_SHARED="ON" -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"
+if errorlevel 1 exit 1
+
 cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: For some reason proj now creates a proj_X_Y.lib so we have to update 
+:: each recipe each time there is a version change. Copy the lib to proj.lib
+FOR /F "tokens=1,2 delims=." %%a IN ("%PKG_VERSION%") DO (
+  set PROJ_MAJOR_VERSION=%%a
+  set PROJ_MINOR_VERSION=%%b
+)
+copy %LIBRARY_LIB%\proj_%PROJ_MAJOR_VERSION%_%PROJ_MINOR_VERSION%.lib %LIBRARY_LIB%\proj.lib
+if errorlevel 1 exit 1
+
 cd ..
 copy /Y data\* %LIBRARY_PREFIX%\\share\\proj
-del /F /Q %LIBRARY_PREFIX%\\share\\proj\\*.cmake
+if errorlevel 1 exit 1
 
+del /F /Q %LIBRARY_PREFIX%\\share\\proj\\*.cmake
 if errorlevel 1 exit 1
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
 mkdir %ACTIVATE_DIR%
+if errorlevel 1 exit 1
 mkdir %DEACTIVATE_DIR%
+if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\proj4-activate.bat
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     folder: data
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
     # Check if NAD27/NAD83 datum shifting is present if `conus` is present.
     - test -f $PREFIX/share/proj/conus  # [not win]
     - if not exist %LIBRARY_PREFIX%\\share\\proj\\conus exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\proj.lib exit 1  # [win]
     - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
     - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
     - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Currently the `.lib` has the version number in it (eg `proj_6_1.lib`) which means we have to update the recipes that use `proj` each time there is a version bump. This PR copies the lib so it is always available as `proj.lib`.

xref: https://github.com/conda-forge/gdal-feedstock/pull/288#discussion_r286301501
