### PR TITLE
Fix activate script for Windows bash in v5.2.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
       win_c_compilervs2008cxx_compilervs2008:
         CONFIG: win_c_compilervs2008cxx_compilervs2008
         CONDA_BLD_PATH: D:\\bld\\
-        UPLOAD_PACKAGES: False
+        UPLOAD_PACKAGES: True
       win_c_compilervs2015cxx_compilervs2015:
         CONFIG: win_c_compilervs2015cxx_compilervs2015
         CONDA_BLD_PATH: D:\\bld\\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     folder: nad
 
 build:
-  number: 1005
+  number: 1006
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -8,8 +8,10 @@ if [[ -n "$PROJ_LIB" ]]; then
 fi
 
 
+# On Linux PROJ_LIB is in $CONDA_PREFIX/share/proj, but
+# Windows keeps it in $CONDA_PREFIX/Library/share
 if [ -d ${CONDA_PREFIX}/share/proj ]; then
   export PROJ_LIB=${CONDA_PREFIX}/share/proj
-elif [ -d ${CONDA_PREFIX}/Library/share/proj ]; then
-  export PROJ_LIB=${CONDA_PREFIX}/Library/share/proj
+elif [ -d ${CONDA_PREFIX}/Library/share ]; then
+  export PROJ_LIB=${CONDA_PREFIX}/Library/share
 fi


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #59 