### PR TITLE
conflict proj with proj4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     folder: data
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
@@ -31,6 +31,8 @@ requirements:
     - sqlite
   run:
     - sqlite
+  run_constrained:
+    - proj4 ==999999999999
 
 test:
   commands:


### PR DESCRIPTION
If I got [our docs](https://conda-forge.org/docs/maintainer/adding_pkgs.html?highlight=run_constrained#constraining-packages-at-runtime) correctly this will disallow the installation of the new `proj` with the old `proj4`.

@jjhelmus I vaguely remember you telling me this. Can you check if I got it right?