### PR TITLE
Rewrite build.sh to use CMake for PROJ 8.1.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,11 +2,18 @@
 
 mkdir -p build && cd build
 
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
+    EXE_SQLITE3=${PREFIX}/bin/sqlite3
+else
+    EXE_SQLITE3=${BUILD_PREFIX}/bin/sqlite3
+fi
+
 cmake ${CMAKE_ARGS} \
       -D CMAKE_BUILD_TYPE=Release \
       -D BUILD_SHARED_LIBS=ON \
       -D CMAKE_INSTALL_PREFIX=${PREFIX} \
       -D CMAKE_INSTALL_LIBDIR=lib \
+      -D EXE_SQLITE3=${EXE_SQLITE3} \
       ${SRC_DIR}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
 
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/gnuconfig/config.* .
+mkdir -p build && cd build
 
-export CFLAGS="-O2 -Wl,-S ${CFLAGS}"
-export CXXFLAGS="-O2 -Wl,-S ${CXXFLAGS}"
+cmake ${CMAKE_ARGS} \
+      -D CMAKE_BUILD_TYPE=Release \
+      -D BUILD_SHARED_LIBS=ON \
+      -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+      -D CMAKE_INSTALL_LIBDIR=lib \
+      ${SRC_DIR}
 
-if [ ! -f configure ]; then
-    ./autogen.sh
-fi
+make -j${CPU_COUNT} ${VERBOSE_CM}
 
-./configure --prefix=${PREFIX} --host=${HOST} --disable-static
-
-make -j${CPU_COUNT}
 # skip tests on linux32 due to rounding error causing issues
 if [[ ! ${HOST} =~ .*linux.* ]] || [[ ! ${ARCH} == 32 ]]; then
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
-    make check -j${CPU_COUNT}
+    ctest --output-on-failure
 fi
 fi
+
 make install -j${CPU_COUNT}
 
 ACTIVATE_DIR=${PREFIX}/etc/conda/activate.d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 22c5cdc5aa0832077b16c95ebeec748a0942811c1c3438c33d43c8d2ead59f48
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: aa5d4b934450149a350aed7e5fbac880e2f7d3fa2f251c26cb64228f96a2109e
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/
@@ -17,14 +17,10 @@ build:
 
 requirements:
   build:
-    - cmake  # [win]
-    - pkg-config  # [not win]
+    - cmake
     - make  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - automake  # [not win]
-    - libtool  # [not win]
-    - gnuconfig  # [not win]
     - sqlite     # [build_platform != target_platform]
   host:
     - sqlite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.0" %}
+{% set version = "8.1.0" %}
 
 package:
   name: proj
@@ -6,10 +6,10 @@ package:
 
 source:
   url: http://download.osgeo.org/proj/proj-{{ version }}.tar.gz
-  sha256: aa5d4b934450149a350aed7e5fbac880e2f7d3fa2f251c26cb64228f96a2109e
+  sha256: 22c5cdc5aa0832077b16c95ebeec748a0942811c1c3438c33d43c8d2ead59f48
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/


### PR DESCRIPTION
#### Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

#### Summary of changes
* Closes #105 
* While PROJ currently support both Autotools and CMake builds, only the CMake build installs modules for CMake's `find_package()`, which can be handy for other projects.