### PR TITLE
Remove gtest from host dependencies

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,25 +8,35 @@ else
     EXE_SQLITE3=${BUILD_PREFIX}/bin/sqlite3
 fi
 
+# skip building and running tests
+echo "CONDA_BUILD_CROSS_COMPILATION=${CONDA_BUILD_CROSS_COMPILATION:-}"
+echo "CROSSCOMPILING_EMULATOR=${CROSSCOMPILING_EMULATOR:-}"
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:-}" != "" ]]; then
+  BUILD_TESTING=OFF
+else
+  # by default make tests to run with ctest after build
+  BUILD_TESTING=ON
+fi
+# temporarily set this on to see what fails...
+BUILD_TESTING=ON
+
 cmake ${CMAKE_ARGS} \
       -D CMAKE_BUILD_TYPE=Release \
       -D BUILD_SHARED_LIBS=ON \
       -D CMAKE_INSTALL_PREFIX=${PREFIX} \
       -D CMAKE_INSTALL_LIBDIR=lib \
       -D EXE_SQLITE3=${EXE_SQLITE3} \
+      -D BUILD_TESTING=${BUILD_TESTING} \
       ${SRC_DIR}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}
 
-# skip unknown test failure with nkg.gie on ppc64le
-if [[ ${HOST} =~ powerpc64le ]]; then
+if [[ ${BUILD_TESTING} = "ON" ]]; then
+  # skip unknown test failure with nkg.gie on ppc64le
+  if [[ ${HOST} =~ powerpc64le ]]; then
     CTEST_ARGS="--exclude-regex nkg"
-fi
-# skip tests on linux32 due to rounding error causing issues
-if [[ ! ${HOST} =~ .*linux.* ]] || [[ ! ${ARCH} == 32 ]]; then
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
-    ctest $CTEST_ARGS --output-on-failure
-fi
+  fi
+  ctest ${CTEST_ARGS} --output-on-failure
 fi
 
 make install -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,17 +8,13 @@ else
     EXE_SQLITE3=${BUILD_PREFIX}/bin/sqlite3
 fi
 
-# skip building and running tests
-echo "CONDA_BUILD_CROSS_COMPILATION=${CONDA_BUILD_CROSS_COMPILATION:-}"
-echo "CROSSCOMPILING_EMULATOR=${CROSSCOMPILING_EMULATOR:-}"
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:-}" != "" ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" && "${CROSSCOMPILING_EMULATOR:-}" == "" ]]; then
+  # skip building and running tests when cross-compiling without an emulator
   BUILD_TESTING=OFF
 else
   # by default make tests to run with ctest after build
   BUILD_TESTING=ON
 fi
-# temporarily set this on to see what fails...
-BUILD_TESTING=ON
 
 cmake ${CMAKE_ARGS} \
       -D CMAKE_BUILD_TYPE=Release \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - define_OLD_BUGGY_REMQUO.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # ABI has been stable across minor versions since 8.0.0
     #    https://abi-laboratory.pro/tracker/timeline/proj/
@@ -25,15 +25,12 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - sqlite  # [build_platform != target_platform]
-    - pytest  # [win]
-    - pyyaml  # [win]
+    - pytest
+    - pyyaml
   host:
     - sqlite
     - libtiff
     - libcurl
-    - gtest  # [not win]
-    - pytest
-    - pyyaml
   run:
     - sqlite
     - libtiff


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

The host dependencies shouldn't have had `gtest` and related test dependencies. This change allows gtest to be downloaded internally by PROJ's cmake and build tests that are run by ctest in the build workflow.

Closes #155