### PR TITLE
Add PowerShell activate.ps1 script

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -63,6 +63,25 @@ if [[ "${sha:-}" == "" ]]; then
   sha=$(git rev-parse HEAD)
 fi
 
+if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
+  if [[ "${CI:-}" == "" ]]; then
+    echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
+    exit 1
+  else
+    export OSX_SDK_DIR=/opt/conda-sdks
+    /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+    /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+  fi
+else
+  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+      rm -f "$tmpf"
+      echo "OSX_SDK_DIR is writeable without sudo, continuing"
+  else
+      echo "User-provided OSX_SDK_DIR is not writeable for current user! Aborting"
+      exit 1
+  fi
+fi
+
 echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -39,3 +39,10 @@ if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\deactivate.sh %DEACTIVATE_DIR%\proj4-deactivate.sh
 if errorlevel 1 exit 1
+
+:: Copy powershell activation scripts
+copy %RECIPE_DIR%\scripts\activate.ps1 %ACTIVATE_DIR%\proj4-activate.ps1
+if errorlevel 1 exit 1
+
+copy %RECIPE_DIR%\scripts\deactivate.ps1 %DEACTIVATE_DIR%\proj4-deactivate.ps1
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-define_OLD_BUGGY_REMQUO.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # ABI has been stable across minor versions since 8.0.0
     #    https://abi-laboratory.pro/tracker/timeline/proj/

--- a/recipe/scripts/activate.ps1
+++ b/recipe/scripts/activate.ps1
@@ -1,0 +1,15 @@
+# Store existing env vars and set to this conda env
+# so other installs don't pollute the environment.
+
+if (Test-Path Env:PROJ_DATA) {
+    $Env:_CONDA_SET_PROJ_DATA = $Env:PROJ_DATA
+}
+
+$Env:PROJ_DATA = Join-Path $Env:CONDA_PREFIX "Library\share\proj"
+
+if (Test-Path (Join-Path $Env:CONDA_PREFIX "Library\share\proj\copyright_and_licenses.csv")) {
+    # proj-data is installed because its license was copied over
+    $Env:PROJ_NETWORK = "OFF"
+} else {
+    $Env:PROJ_NETWORK = "ON"
+}

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,4 +1,4 @@
-:: Restore previous GDAL env vars if they were set.
+:: Restore previous PROJ env vars if they were set.
 
 @set "PROJ_DATA="
 @set "PROJ_NETWORK="

--- a/recipe/scripts/deactivate.ps1
+++ b/recipe/scripts/deactivate.ps1
@@ -1,0 +1,9 @@
+Remove-Item ENV:PROJ_DATA -ErrorAction Ignore
+Remove-Item ENV:PROJ_NETWORK -ErrorAction Ignore
+
+# Restore previous PROJ env vars if they were set
+
+if ($ENV:_CONDA_SET_PROJ_DATA) {
+  $ENV:PROJ_DATA = $ENV:_CONDA_SET_PROJ_DATA
+  Remove-Item ENV:_CONDA_SET_PROJ_DATA
+}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR adds an activation script for PowerShell similar to the [activate.bat](https://github.com/conda-forge/proj.4-feedstock/blob/main/recipe/scripts/activate.bat).

This approach works for GDAL on Windows/PowerShell - https://github.com/conda-forge/gdal-feedstock/blob/main/recipe/scripts/activate.ps1

Note on Windows the environment variables are only set after activating the environment, not after a `conda install proj`. This seems to be a general Conda/PowerShell issue, see also https://github.com/conda-forge/gdal-feedstock/issues/1100.

If merged, `PROJ_DATA` should be set following a `conda activate myenv` for any environment containing `proj`. 