### PR TITLE
Fixes unintended non-zero exit status from the activation script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "proj.4-feedstock"
-version = "3.54.1"  # conda-smithy version used to generate this file
+version = "3.54.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/proj.4-feedstock"
 authors = ["@conda-forge/proj.4"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-define_OLD_BUGGY_REMQUO.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipe/scripts/activate.fish
+++ b/recipe/scripts/activate.fish
@@ -2,17 +2,17 @@
 
 if set -q PROJ_DATA
   set -gx _CONDA_SET_PROJ_DATA "$PROJ_DATA"
-end
+end; or true
 
 if test -d "$CONDA_PREFIX/share/proj"
   set -gx PROJ_DATA "$CONDA_PREFIX/share/proj"
 else if test -d "$CONDA_PREFIX/Library/share/proj"
   set -gx PROJ_DATA "$CONDA_PREFIX/Library/share/proj"
-end
+end; or true
 
 if test -f "$CONDA_PREFIX/share/proj/copyright_and_licenses.csv"
   # proj-data is installed because its license was copied over
   set -gx PROJ_NETWORK "OFF"
 else
   set -gx PROJ_NETWORK "ON"
-end
+end; or true


### PR DESCRIPTION
## Fixes #168

The Fish activation script at `recipe/scripts/activate.fish` causes `micromamba activate` (and `conda activate`) to return non-zero exit status (status `1`) even when activation succeeds. This patch fixes that issue.

---
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
